### PR TITLE
Un-stealth visited links

### DIFF
--- a/Fedora/resources/screen-common.less
+++ b/Fedora/resources/screen-common.less
@@ -118,10 +118,6 @@ a:visited.btn-primary{
 	color:white;
 }
 
-a:visited{
-	color:inherit;
-}
-
 //remove discussion tab from main page
 //we also remove the main tab here, because it doesn't really
 //make sense once removing the discussion tab


### PR DESCRIPTION
`a:visited { color:inherit }` causes visited links to inherit the body text color, making them undetectable.

Fixes #1