### PR TITLE
Add/update skin metadata

### DIFF
--- a/Fedora/i18n/en.json
+++ b/Fedora/i18n/en.json
@@ -2,6 +2,6 @@
 	"@metadata": {
 		"authors": [ "..." ]
 	},
-	"skinname-example": "Example",
-	"example-desc": "An example skin showcasing the best practices"
+	"skinname-fedora": "Fedora",
+	"fedora-desc": "The default theme for fedoraproject.org/wiki"
 }

--- a/Fedora/skin.json
+++ b/Fedora/skin.json
@@ -5,7 +5,7 @@
 	"url": "https://github.com/fedora-infra/fedora-mediawiki-theme/",
 	"descriptionmsg": "fedora-desc",
 	"namemsg": "skinname-fedora",
-	"license-name": "GPLv2+",
+	"license-name": "GPL-2.0-or-later",
 	"type": "skin",
 	"ValidSkinNames": {
 		"fedora": "Fedora"


### PR DESCRIPTION
This PR creates the `skinname-fedora` and `fedora-desc` messages named in the `skin.json` file, and replaces the `GPLv2+` license name with a modern SPDX `GPL-2.0-or-later` license expression.

As a result, the skin is identified properly on the `Special:Version` page, and looks like all of the others:

![image](https://github.com/user-attachments/assets/9bfdce15-0b4b-413e-b2e4-b224639cf029)
